### PR TITLE
invert primary text colors

### DIFF
--- a/osu.Game.Tournament/Components/DrawableTeamWithPlayers.cs
+++ b/osu.Game.Tournament/Components/DrawableTeamWithPlayers.cs
@@ -65,7 +65,7 @@ namespace osu.Game.Tournament.Components
                 {
                     Text = p.Username,
                     Font = OsuFont.Torus.With(size: 24, weight: FontWeight.SemiBold),
-                    Colour = Color4.White,
+                    Colour = TournamentGame.TEXT_COLOUR,
                 };
         }
     }

--- a/osu.Game.Tournament/Components/DrawableTournamentTeam.cs
+++ b/osu.Game.Tournament/Components/DrawableTournamentTeam.cs
@@ -28,6 +28,7 @@ namespace osu.Game.Tournament.Components
             AcronymText = new TournamentSpriteText
             {
                 Font = OsuFont.Torus.With(weight: FontWeight.Regular),
+                Colour = TournamentGame.TEXT_COLOUR
             };
         }
 

--- a/osu.Game.Tournament/Components/SongBar.cs
+++ b/osu.Game.Tournament/Components/SongBar.cs
@@ -242,6 +242,7 @@ namespace osu.Game.Tournament.Components
                                                 X = -10,
                                                 Anchor = Anchor.CentreRight,
                                                 Origin = Anchor.CentreRight,
+                                                Colour = TournamentGame.ELEMENT_BACKGROUND_COLOUR
                                             },
                                         }
                                     },
@@ -283,6 +284,7 @@ namespace osu.Game.Tournament.Components
                         {
                             cp(s, false);
                             s.Spacing = new Vector2(-2, 0);
+                            Colour = TournamentGame.TEXT_COLOUR;
                         });
                     }
 

--- a/osu.Game.Tournament/Components/TournamentBeatmapPanel.cs
+++ b/osu.Game.Tournament/Components/TournamentBeatmapPanel.cs
@@ -73,6 +73,7 @@ namespace osu.Game.Tournament.Components
                         {
                             Text = Beatmap?.GetDisplayTitleRomanisable(false, false) ?? (LocalisableString)@"unknown",
                             Font = OsuFont.Torus.With(weight: FontWeight.Bold),
+                            Colour = Color4.White,
                         },
                         new FillFlowContainer
                         {
@@ -84,24 +85,28 @@ namespace osu.Game.Tournament.Components
                                 {
                                     Text = "mapper",
                                     Padding = new MarginPadding { Right = 5 },
-                                    Font = OsuFont.Torus.With(weight: FontWeight.Regular, size: 14)
+                                    Font = OsuFont.Torus.With(weight: FontWeight.Regular, size: 14),
+                                    Colour = Color4.White
                                 },
                                 new TournamentSpriteText
                                 {
                                     Text = Beatmap?.Metadata.Author.Username ?? "unknown",
                                     Padding = new MarginPadding { Right = 20 },
-                                    Font = OsuFont.Torus.With(weight: FontWeight.Bold, size: 14)
+                                    Font = OsuFont.Torus.With(weight: FontWeight.Bold, size: 14),
+                                    Colour = Color4.White
                                 },
                                 new TournamentSpriteText
                                 {
                                     Text = "difficulty",
                                     Padding = new MarginPadding { Right = 5 },
-                                    Font = OsuFont.Torus.With(weight: FontWeight.Regular, size: 14)
+                                    Font = OsuFont.Torus.With(weight: FontWeight.Regular, size: 14),
+                                    Colour = Color4.White
                                 },
                                 new TournamentSpriteText
                                 {
                                     Text = Beatmap?.DifficultyName ?? "unknown",
-                                    Font = OsuFont.Torus.With(weight: FontWeight.Bold, size: 14)
+                                    Font = OsuFont.Torus.With(weight: FontWeight.Bold, size: 14),
+                                    Colour = Color4.White
                                 },
                             }
                         }

--- a/osu.Game.Tournament/Screens/Ladder/Components/DrawableMatchTeam.cs
+++ b/osu.Game.Tournament/Screens/Ladder/Components/DrawableMatchTeam.cs
@@ -178,10 +178,10 @@ namespace osu.Game.Tournament.Screens.Ladder.Components
         {
             bool winner = completed.Value && isWinner?.Invoke() == true;
 
-            background.FadeColour(winner ? Color4.White : Color4Extensions.FromHex("#444"), winner ? 500 : 0, Easing.OutQuint);
+            background.FadeColour(winner ? TournamentGame.ELEMENT_BACKGROUND_COLOUR : Color4Extensions.FromHex("#444"), winner ? 500 : 0, Easing.OutQuint);
             backgroundRight.FadeColour(winner ? colourWinner : Color4Extensions.FromHex("#333"), winner ? 500 : 0, Easing.OutQuint);
 
-            AcronymText.Colour = winner ? Color4.Black : Color4.White;
+            AcronymText.Colour = winner ? TournamentGame.ELEMENT_FOREGROUND_COLOUR : TournamentGame.ELEMENT_BACKGROUND_COLOUR;
 
             scoreText.Font = scoreText.Font.With(weight: winner ? FontWeight.Bold : FontWeight.Regular);
         }

--- a/osu.Game.Tournament/Screens/Ladder/Components/DrawableTournamentMatch.cs
+++ b/osu.Game.Tournament/Screens/Ladder/Components/DrawableTournamentMatch.cs
@@ -85,7 +85,7 @@ namespace osu.Game.Tournament.Screens.Ladder.Components
                     {
                         RelativeSizeAxes = Axes.Both,
                         Alpha = 0,
-                        BorderColour = Color4.White,
+                        BorderColour = TournamentGame.ELEMENT_BACKGROUND_COLOUR,
                         BorderThickness = border_thickness,
                         Masking = true,
                         Child = new Box

--- a/osu.Game.Tournament/Screens/Schedule/ScheduleScreen.cs
+++ b/osu.Game.Tournament/Screens/Schedule/ScheduleScreen.cs
@@ -14,7 +14,6 @@ using osu.Game.Tournament.Components;
 using osu.Game.Tournament.Models;
 using osu.Game.Tournament.Screens.Ladder.Components;
 using osuTK;
-using osuTK.Graphics;
 
 namespace osu.Game.Tournament.Screens.Schedule
 {
@@ -72,7 +71,7 @@ namespace osu.Game.Tournament.Screens.Schedule
                                                 {
                                                     new Box
                                                     {
-                                                        Colour = Color4.White,
+                                                        Colour = TournamentGame.ELEMENT_BACKGROUND_COLOUR,
                                                         Size = new Vector2(50, 10),
                                                     },
                                                     new TournamentSpriteTextWithBackground("Schedule")
@@ -262,6 +261,7 @@ namespace osu.Game.Tournament.Screens.Schedule
             public ScheduleMatchDate(DateTimeOffset date, float textSize = OsuFont.DEFAULT_FONT_SIZE, bool italic = true)
                 : base(date, textSize, italic)
             {
+                Colour = TournamentGame.TEXT_COLOUR;
             }
 
             protected override string Format() => Date < DateTimeOffset.Now

--- a/osu.Game.Tournament/TournamentGame.cs
+++ b/osu.Game.Tournament/TournamentGame.cs
@@ -28,10 +28,10 @@ namespace osu.Game.Tournament
         public static readonly Color4 COLOUR_RED = new OsuColour().TeamColourRed;
         public static readonly Color4 COLOUR_BLUE = new OsuColour().TeamColourBlue;
 
-        public static readonly Color4 ELEMENT_BACKGROUND_COLOUR = Color4Extensions.FromHex("#fff");
-        public static readonly Color4 ELEMENT_FOREGROUND_COLOUR = Color4Extensions.FromHex("#000");
+        public static readonly Color4 ELEMENT_FOREGROUND_COLOUR = Color4Extensions.FromHex("#fff");
+        public static readonly Color4 ELEMENT_BACKGROUND_COLOUR = Color4Extensions.FromHex("#000");
 
-        public static readonly Color4 TEXT_COLOUR = Color4Extensions.FromHex("#fff");
+        public static readonly Color4 TEXT_COLOUR = Color4Extensions.FromHex("#000");
         private Drawable heightWarning = null!;
 
         private Bindable<WindowMode> windowMode = null!;

--- a/osu.Game.Tournament/TournamentSpriteText.cs
+++ b/osu.Game.Tournament/TournamentSpriteText.cs
@@ -11,6 +11,7 @@ namespace osu.Game.Tournament
         public TournamentSpriteText()
         {
             Font = OsuFont.Torus;
+            Colour = TournamentGame.TEXT_COLOUR;
         }
     }
 }

--- a/osu.Game/Screens/Play/HUD/MatchScoreDisplay.cs
+++ b/osu.Game/Screens/Play/HUD/MatchScoreDisplay.cs
@@ -4,6 +4,7 @@
 using System;
 using osu.Framework.Allocation;
 using osu.Framework.Bindables;
+using osu.Framework.Extensions.Color4Extensions;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
 using osu.Framework.Graphics.Shapes;
@@ -169,6 +170,8 @@ namespace osu.Game.Screens.Play.HUD
             public MatchScoreCounter()
             {
                 Margin = new MarginPadding { Top = bar_height, Horizontal = 10 };
+                // hardcoding to #000, this component isn't under `TournamentGame`.
+                Colour = Color4Extensions.FromHex("#000");
             }
 
             public bool Winning
@@ -191,6 +194,11 @@ namespace osu.Game.Screens.Play.HUD
 
         private partial class MatchScoreDiffCounter : CommaSeparatedScoreCounter
         {
+            public MatchScoreDiffCounter()
+            {
+                Colour = Color4Extensions.FromHex("#000");
+            }
+
             protected override OsuSpriteText CreateSpriteText() => base.CreateSpriteText().With(s =>
             {
                 s.Spacing = new Vector2(-2);


### PR DESCRIPTION
> [3:40 AM]D I O: @ilw8 yo possible to get a version of lazer client with inverted overlay colors? so basically just wherever it's white text or borders or boxes change to black and vice versa


- text without a background are now black

- text with background have been inverted; 
    - they were previously black on white background
    - they are now white on black background