### PR TITLE
adjust match header elements positioning

### DIFF
--- a/osu.Game.Tournament/Screens/Gameplay/Components/MatchHeader.cs
+++ b/osu.Game.Tournament/Screens/Gameplay/Components/MatchHeader.cs
@@ -78,6 +78,7 @@ namespace osu.Game.Tournament.Screens.Gameplay.Components
                         },
                         new MatchRoundDisplay
                         {
+                            Margin = new MarginPadding { Top = 72 },
                             Anchor = Anchor.TopCentre,
                             Origin = Anchor.TopCentre,
                             Scale = new Vector2(0.4f)

--- a/osu.Game.Tournament/Screens/Gameplay/Components/TeamDisplay.cs
+++ b/osu.Game.Tournament/Screens/Gameplay/Components/TeamDisplay.cs
@@ -49,7 +49,12 @@ namespace osu.Game.Tournament.Screens.Gameplay.Components
             Flag.Origin = anchor;
             Flag.Anchor = anchor;
 
-            Margin = new MarginPadding(20);
+            Margin = new MarginPadding
+            {
+                Top = 12,
+                Horizontal = 20,
+                Bottom = 20
+            };
 
             InternalChild = new Container
             {

--- a/osu.Game.Tournament/Screens/MapPool/MapPoolScreen.cs
+++ b/osu.Game.Tournament/Screens/MapPool/MapPoolScreen.cs
@@ -53,6 +53,7 @@ namespace osu.Game.Tournament.Screens.MapPool
                 },
                 new MatchHeader
                 {
+                    ShowLogo = false,
                     ShowScores = true,
                 },
                 mapFlows = new FillFlowContainer<FillFlowContainer<TournamentBeatmapPanel>>


### PR DESCRIPTION
> last edits i swear (probably), possible to make the round name show up lower on the gameplay screen and the team info show up slightly higher on both gameplay and mappool? https://i.imgur.com/CF7Z8JW.png